### PR TITLE
certora: update properties

### DIFF
--- a/.github/workflows/Certora.yaml
+++ b/.github/workflows/Certora.yaml
@@ -26,7 +26,7 @@ jobs:
         with: { python-version: 3.9 }
 
       - name: Install certora cli
-        run: pip3 install certora-cli==4.5.1
+        run: pip3 install certora-cli==4.8.0
       
       - name: Install solc
         run: |

--- a/certora/account-state.spec
+++ b/certora/account-state.spec
@@ -41,7 +41,6 @@ function collateralIdFromTokenMatch(address acc) returns bool {
 invariant account_no_unknown_debt(env e, address acc) noShortAmountWithoutShortId(acc);
 
 /// if shorted token id is 0 (no short), then short amount MUST be 0. Vice versa.
-// todo: reserach better method than reverting collatId == 0 in code.
 invariant account_no_unknown_collateral(env e, address acc) noCollatAmountWithoutCollatId(acc);
 
 
@@ -54,5 +53,3 @@ invariant account_collateral_match(env e, address acc) collateralIdFromTokenMatc
       require(accountIsEmpty(acc));
     }
 }
-
-invariant account_has_enough_collateral(env e, address acc) accountWellCollateralized(acc);

--- a/certora/account-state.spec
+++ b/certora/account-state.spec
@@ -54,3 +54,5 @@ invariant account_collateral_match(env e, address acc) collateralIdFromTokenMatc
       require(accountIsEmpty(acc));
     }
 }
+
+invariant account_has_enough_collateral(env e, address acc) accountWellCollateralized(acc);

--- a/certora/base.spec
+++ b/certora/base.spec
@@ -2,7 +2,7 @@
  *              Declarations
  * ======================================= */
 methods {
-  function getMinCollateral(address) external returns(uint) envfree; 
+  function getMinCollateral(address) external returns(uint256) envfree; 
 
   function marginAccounts(address) external returns(uint256, uint64, uint8, uint80) envfree;
 
@@ -14,7 +14,10 @@ methods {
 
   function optionToken() external returns (address) envfree;
 
-  function allowedExecutionLeft(uint160,address) external returns (uint) envfree;
+  function allowedExecutionLeft(uint160,address) external returns (uint256) envfree;
+
+  // functions defined in Hardness
+  function getMinCollateralByTokenId(uint256) external returns (uint256) envfree;
 }
 
 /* ======================================= *
@@ -54,4 +57,10 @@ function accountIsEmpty(address acc) returns bool {
     uint256 shortId; uint64 shortAmount; uint256 collatId; uint80 collatAmount;
     shortId, shortAmount, collatId, collatAmount = marginAccounts(acc);
     return shortAmount == 0 && collatAmount == 0 && shortId == 0 && collatId == 0;
+}
+
+function accountWellCollateralized(address acc) returns bool {
+    uint collateralRequied = getMinCollateral(acc);
+    uint collateralDeposited = getAccountCollateralAmount(acc);
+    return collateralDeposited >= collateralRequied;
 }

--- a/certora/engine-grappa.spec
+++ b/certora/engine-grappa.spec
@@ -85,6 +85,7 @@ rule call_spread_fully_collateralized_by_strike(uint256 tokenId) {
     check_token_type_fully_collateralized(3, tokenId);
 }
 
+/// if a call spread is collateralized by underlying asset, payout is always covered by collateral reguardless of underlying (collateral) price
 rule call_spread_fully_collateralized_by_underlying(uint256 tokenId) {
     address underlying; address strike; address collateral; uint8 underlyingId; uint8 collateralId;
     _, underlying, strike, collateral, underlyingId, _, collateralId  = grappa.parseAssetsFromTokenId(tokenId);
@@ -99,8 +100,10 @@ rule call_spread_fully_collateralized_by_underlying(uint256 tokenId) {
     expiryPrice, isFinalized = oracle.getPriceAtExpiry(underlying, strike, expiry);
 
     require isFinalized;
-    // require expiryPrice > assert_uint256(longStrike);
-    require expiryPrice > assert_uint256(shortStrike);
+
+    // adding both requirements won't help time out 
+    require expiryPrice > assert_uint256(longStrike);
+    require expiryPrice < assert_uint256(shortStrike);
     
     check_token_type_fully_collateralized(3, tokenId);
 }

--- a/certora/engine-grappa.spec
+++ b/certora/engine-grappa.spec
@@ -1,8 +1,8 @@
 import "base.spec";
 import "account-state.spec";
 
-using GrappaExtended as grappa;
-using FullMarginEngineExtended as engine;
+using GrappaHarness as grappa;
+using FullMarginEngineHarness as engine;
 
 methods {
   // calling grappa.assets should not change over time
@@ -10,7 +10,7 @@ methods {
 
   function grappa.getPayout(uint256,uint64) external returns (address,address,uint256);
 
-  function grappa.checkIsValidTokenIdToMint(uint256) external;
+  function grappa.checkIsValidTokenIdToMint(uint256) external envfree;
 
   function engine.checkTokenIdToMint(uint256) external envfree;
 }
@@ -42,11 +42,11 @@ rule accountAlwaysSolvent(address acc) {
 
     require accountWellCollateralized(acc);
     require collateralIdFromTokenMatch(acc);
-    
+
     uint256 tokenId; uint64 shortAmount; uint256 collatAmount; address collateral; uint256 payout; uint8 collatId;
 
     tokenId, shortAmount, collatId, collatAmount = marginAccounts(acc);
-    
+
     // ensure that the tokenId in the account storage is valid
     engine.checkTokenIdToMint(tokenId);
     grappa.checkIsValidTokenIdToMint(e, tokenId);
@@ -56,4 +56,4 @@ rule accountAlwaysSolvent(address acc) {
     _, _, payout = grappa.getPayout(e, tokenId, shortAmount);
 
     assert collatAmount >= payout;
- }
+}

--- a/certora/engine-grappa.spec
+++ b/certora/engine-grappa.spec
@@ -3,6 +3,7 @@ import "account-state.spec";
 
 using GrappaHarness as grappa;
 using FullMarginEngineHarness as engine;
+using MockOracle as oracle;
 
 methods {
   function grappa.assets(uint8) external returns(address, uint8) envfree;
@@ -11,18 +12,35 @@ methods {
 
   function grappa.checkIsValidTokenIdToMint(uint256) external;
 
-  function grappa.parseAssetsFromTokenId(uint256) external returns (uint8, address, address,address) envfree;
+  function grappa.parseAssetsFromTokenId(uint256) external returns (uint8, address, address,address, uint8, uint8, uint8) envfree;
+
+  function grappa.parseExpiryAndStrikes(uint256) external returns (uint64, uint64, uint64) envfree;
 
   function engine.checkTokenIdToMint(uint256) external envfree;
+
+  /// use MockOracle as a reference implementation
+  function _.getPriceAtExpiry(address, address, uint256) external => DISPATCHER(true);
+
+  function oracle.getPriceAtExpiry(address, address, uint256) external returns (uint256, bool) envfree;
 }
 
+definition UNIT() returns uint64 = 10^6;
+
+/**
+ * Check if a particular token type is fully collateralized, in other words, no matter what the price is at expiry, 
+ * the payout can always be covered by required collateral
+ * 
+ * We need to split the spec to mutiple rules to avoid hitting timeouts
+ **/
 function check_token_type_fully_collateralized(uint8 tokenTypeToCheck, uint256 tokenId) {
     env e;
-
-    // assume this token doesn't have underlying == strike (ETH - ETH option)
-    address underlying; address strike; uint8 tokenType;
-    tokenType, underlying, strike, _  = grappa.parseAssetsFromTokenId(e, tokenId);
+    // assume this token doesn't have underlying == strike (something like ETH - ETH option)
+    uint8 tokenType; address underlying; address strike; uint8 underlyingId; uint8 strikeId;
+    tokenType, underlying, strike, _, underlyingId, strikeId, _ = grappa.parseAssetsFromTokenId(tokenId);
     require underlying != strike; 
+    require underlyingId != strikeId;
+
+    // satisfy input token type to check
     require tokenType == tokenTypeToCheck;
 
     // ensure that the tokenId is valid to be minted by Grappa (inclulding not expired)
@@ -36,7 +54,7 @@ function check_token_type_fully_collateralized(uint8 tokenTypeToCheck, uint256 t
 
     // query grappa at settlement, with amount of token this account minted
     uint256 payout;
-    _, _, payout = grappa.getPayout(e2, tokenId, 1000000);
+    _, _, payout = grappa.getPayout(e2, tokenId, UNIT());
 
     uint256 collateralRequirement;
     collateralRequirement = engine.getMinCollateralByTokenId(tokenId);
@@ -60,6 +78,29 @@ rule call_fully_collateralized(uint256 tokenId) {
     check_token_type_fully_collateralized(2, tokenId);
 }
 
-// rule call_spread_fully_collateralized(uint256 tokenId) {
-//     check_token_type_fully_collateralized(3, tokenId);
-// }
+rule call_spread_fully_collateralized_by_strike(uint256 tokenId) {
+    address strike; address collateral;
+    _, _, strike, collateral, _, _, _  = grappa.parseAssetsFromTokenId(tokenId);
+    require collateral == strike;
+    check_token_type_fully_collateralized(3, tokenId);
+}
+
+rule call_spread_fully_collateralized_by_underlying(uint256 tokenId) {
+    address underlying; address strike; address collateral; uint8 underlyingId; uint8 collateralId;
+    _, underlying, strike, collateral, underlyingId, _, collateralId  = grappa.parseAssetsFromTokenId(tokenId);
+    
+    require collateral == underlying;
+    // extra constraint to specify ids are the same, 
+    // excluding the scenarios where Grappa could have multiple ids point to same address or vice versa (which is impossible)
+    require collateralId == underlyingId;
+
+    uint64 longStrike; uint64 shortStrike; uint256 expiryPrice; bool isFinalized; uint64 expiry;
+    expiry, longStrike, shortStrike = grappa.parseExpiryAndStrikes(tokenId);
+    expiryPrice, isFinalized = oracle.getPriceAtExpiry(underlying, strike, expiry);
+
+    require isFinalized;
+    // require expiryPrice > assert_uint256(longStrike);
+    require expiryPrice > assert_uint256(shortStrike);
+    
+    check_token_type_fully_collateralized(3, tokenId);
+}

--- a/certora/engine-grappa.spec
+++ b/certora/engine-grappa.spec
@@ -46,7 +46,6 @@ function check_token_type_fully_collateralized(uint8 tokenTypeToCheck, uint256 t
     // ensure that the tokenId is valid to be minted by Grappa (inclulding not expired)
     grappa.checkIsValidTokenIdToMint(e, tokenId);
     engine.checkTokenIdToMint(tokenId);
-    require !lastReverted;
 
     // different env, pass of time is allowed
     env e2;
@@ -86,24 +85,20 @@ rule call_spread_fully_collateralized_by_strike(uint256 tokenId) {
 }
 
 /// if a call spread is collateralized by underlying asset, payout is always covered by collateral reguardless of underlying (collateral) price
-rule call_spread_fully_collateralized_by_underlying(uint256 tokenId) {
-    address underlying; address strike; address collateral; uint8 underlyingId; uint8 collateralId;
-    _, underlying, strike, collateral, underlyingId, _, collateralId  = grappa.parseAssetsFromTokenId(tokenId);
+// rule call_spread_fully_collateralized_by_underlying(uint256 tokenId) {
+//     address underlying; address strike; address collateral; uint8 underlyingId; uint8 collateralId;
+//     _, underlying, strike, collateral, underlyingId, _, collateralId  = grappa.parseAssetsFromTokenId(tokenId);
     
-    require collateral == underlying;
-    // extra constraint to specify ids are the same, 
-    // excluding the scenarios where Grappa could have multiple ids point to same address or vice versa (which is impossible)
-    require collateralId == underlyingId;
+//     require collateral == underlying;
+//     // extra constraint to specify ids are the same, 
+//     // excluding the scenarios where Grappa could have multiple ids point to same address or vice versa (which is impossible)
+//     require collateralId == underlyingId;
 
-    uint64 longStrike; uint64 shortStrike; uint256 expiryPrice; bool isFinalized; uint64 expiry;
-    expiry, longStrike, shortStrike = grappa.parseExpiryAndStrikes(tokenId);
-    expiryPrice, isFinalized = oracle.getPriceAtExpiry(underlying, strike, expiry);
+//     uint64 longStrike; uint64 shortStrike; uint256 expiryPrice; bool isFinalized; uint64 expiry;
+//     expiry, longStrike, shortStrike = grappa.parseExpiryAndStrikes(tokenId);
+//     expiryPrice, isFinalized = oracle.getPriceAtExpiry(underlying, strike, expiry);
 
-    require isFinalized;
-
-    // adding both requirements won't help time out 
-    require expiryPrice > assert_uint256(longStrike);
-    require expiryPrice < assert_uint256(shortStrike);
+//     require isFinalized;
     
-    check_token_type_fully_collateralized(3, tokenId);
-}
+//     check_token_type_fully_collateralized(3, tokenId);
+// }

--- a/certora/harness/FullMarginEngineHarness.sol
+++ b/certora/harness/FullMarginEngineHarness.sol
@@ -33,14 +33,14 @@ contract FullMarginEngineHarness is FullMarginEngine {
 
     (, uint8 collateralDecimals) = grappa.assets(collateralId);
     FullMarginDetail memory detail = FullMarginDetail({
-            shortAmount: 1000000, // 1 unit
-            longStrike: secondaryStrike,
-            shortStrike: primaryStrike,
-            collateralAmount: 0,
-            collateralDecimals: collateralDecimals,
-            collateralizedWithStrike: collateralizedWithStrike,
-            tokenType: tokenType
-        });
+        shortAmount: 1000000, // 1 unit
+        longStrike: secondaryStrike,
+        shortStrike: primaryStrike,
+        collateralAmount: 0,
+        collateralDecimals: collateralDecimals,
+        collateralizedWithStrike: collateralizedWithStrike,
+        tokenType: tokenType
+    });
     return FullMarginMath.getCollateralRequirement(detail);
   }
 }

--- a/certora/harness/FullMarginEngineHarness.sol
+++ b/certora/harness/FullMarginEngineHarness.sol
@@ -9,10 +9,10 @@ import {ProductIdUtil} from "grappa-core/libraries/ProductIdUtil.sol";
 import {TokenType} from  "grappa-core/config/enums.sol";
 
 /**
- * @title FullMarginEngineExtended
+ * @title FullMarginEngineHarness
  * @dev expose more functions for certora formal verification
  */
-contract FullMarginEngineExtended is FullMarginEngine {
+contract FullMarginEngineHarness is FullMarginEngine {
   constructor(address _grappa, address _optionToken) FullMarginEngine(_grappa, _optionToken) {}
 
   function checkTokenIdToMint(uint256 tokenId) external view {

--- a/certora/harness/FullMarginEngineHarness.sol
+++ b/certora/harness/FullMarginEngineHarness.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.0;
 
 import {FullMarginEngine} from "src/FullMarginEngine.sol";
 import {FullMarginLib} from "src/FullMarginLib.sol";
+import {FullMarginMath} from "src/FullMarginMath.sol";
+import {FullMarginDetail} from "src/types.sol";
+
 import {TokenIdUtil} from  "grappa-core/libraries/TokenIdUtil.sol";
 import {ProductIdUtil} from "grappa-core/libraries/ProductIdUtil.sol";
 
@@ -19,5 +22,25 @@ contract FullMarginEngineHarness is FullMarginEngine {
     (TokenType optionType, uint40 productId,,,) = TokenIdUtil.parseTokenId(tokenId);
     (,, uint8 underlyingId, uint8 strikeId, uint8 collateralId) = ProductIdUtil.parseProductId(productId);
     FullMarginLib.checkProductToMint(optionType, underlyingId, strikeId, collateralId);
+  }
+
+  function getMinCollateralByTokenId(uint256 tokenId) external view returns (uint256) {
+    (TokenType tokenType, uint40 productId,, uint64 primaryStrike, uint64 secondaryStrike) = TokenIdUtil.parseTokenId(tokenId);
+
+    (,,, uint8 strikeId, uint8 collateralId) = ProductIdUtil.parseProductId(productId);
+
+    bool collateralizedWithStrike = collateralId == strikeId;
+
+    (, uint8 collateralDecimals) = grappa.assets(collateralId);
+    FullMarginDetail memory detail = FullMarginDetail({
+            shortAmount: 1000000, // 1 unit
+            longStrike: secondaryStrike,
+            shortStrike: primaryStrike,
+            collateralAmount: 0,
+            collateralDecimals: collateralDecimals,
+            collateralizedWithStrike: collateralizedWithStrike,
+            tokenType: tokenType
+        });
+    return FullMarginMath.getCollateralRequirement(detail);
   }
 }

--- a/certora/harness/GrappaHarness.sol
+++ b/certora/harness/GrappaHarness.sol
@@ -18,15 +18,27 @@ contract GrappaHarness is Grappa {
     (, , payout) = _getPayoutPerToken(tokenId);
   }
 
-  function parseAssetsFromTokenId(uint256 tokenId) external view returns (uint8 tokenTypeUint8, address underlying, address strike, address collateral) {
+  function parseAssetsFromTokenId(uint256 tokenId) external view returns (
+    uint8 tokenTypeUint8, 
+    address underlying, 
+    address strike, 
+    address collateral,
+    uint8 underlyingId,
+    uint8 strikeId,
+    uint8 collateralId
+  ) {
     
     (TokenType tokenType, uint40 productId, , , ) = TokenIdUtil.parseTokenId(tokenId);
-    (, , uint8 underlyingId, uint8 strikeId, uint8 collateralId) = ProductIdUtil.parseProductId(productId);
+    (, , underlyingId, strikeId, collateralId) = ProductIdUtil.parseProductId(productId);
     underlying = assets[underlyingId].addr;
     strike = assets[strikeId].addr;
     collateral = assets[collateralId].addr;
 
     tokenTypeUint8 = uint8(tokenType);
 
+  }
+
+  function parseExpiryAndStrikes(uint256 tokenId) external view returns (uint64 expiry, uint64 primary, uint64 secondary) {
+    (, , expiry, primary, secondary) = TokenIdUtil.parseTokenId(tokenId);
   }
 }

--- a/certora/harness/GrappaHarness.sol
+++ b/certora/harness/GrappaHarness.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import {Grappa} from "grappa-core/core/Grappa.sol";
 
-contract GrappaExtended is Grappa {
+contract GrappaHarness is Grappa {
   constructor(address _optionToken) Grappa (_optionToken) {}
 
   function checkIsValidTokenIdToMint(uint256 tokenId) external view {

--- a/certora/harness/GrappaHarness.sol
+++ b/certora/harness/GrappaHarness.sol
@@ -3,11 +3,30 @@ pragma solidity ^0.8.0;
 
 
 import {Grappa} from "grappa-core/core/Grappa.sol";
+import {TokenIdUtil} from "grappa-core/libraries/TokenIdUtil.sol";
+import {ProductIdUtil} from "grappa-core/libraries/ProductIdUtil.sol";
+import {TokenType} from  "grappa-core/config/enums.sol";
 
 contract GrappaHarness is Grappa {
   constructor(address _optionToken) Grappa (_optionToken) {}
 
   function checkIsValidTokenIdToMint(uint256 tokenId) external view {
     return _isValidTokenIdToMint(tokenId);
+  }
+
+  function getPayoutPerToken(uint256 tokenId) external view returns (uint256 payout) {
+    (, , payout) = _getPayoutPerToken(tokenId);
+  }
+
+  function parseAssetsFromTokenId(uint256 tokenId) external view returns (uint8 tokenTypeUint8, address underlying, address strike, address collateral) {
+    
+    (TokenType tokenType, uint40 productId, , , ) = TokenIdUtil.parseTokenId(tokenId);
+    (, , uint8 underlyingId, uint8 strikeId, uint8 collateralId) = ProductIdUtil.parseProductId(productId);
+    underlying = assets[underlyingId].addr;
+    strike = assets[strikeId].addr;
+    collateral = assets[collateralId].addr;
+
+    tokenTypeUint8 = uint8(tokenType);
+
   }
 }

--- a/certora/verify-account-state.sh
+++ b/certora/verify-account-state.sh
@@ -1,5 +1,5 @@
-certoraRun src/FullMarginEngine.sol \
-    --verify FullMarginEngine:certora/account-state.spec \
+certoraRun certora/harness/FullMarginEngineHarness.sol \
+    --verify FullMarginEngineHarness:certora/account-state.spec \
     --solc_allow_path src \
     --optimistic_loop \
     --packages  solmate=lib/solmate/src \

--- a/certora/verify-engine.sh
+++ b/certora/verify-engine.sh
@@ -1,4 +1,4 @@
-certoraRun certora/harness/FullMarginEngineHarness.sol certora/harness/GrappaHarness.sol \
+certoraRun certora/harness/FullMarginEngineHarness.sol certora/harness/GrappaHarness.sol test/mocks/MockOracle.sol \
     --verify FullMarginEngineHarness:certora/engine-grappa.spec \
     --link FullMarginEngineHarness:grappa=GrappaHarness \
     --solc_allow_path src \

--- a/certora/verify-engine.sh
+++ b/certora/verify-engine.sh
@@ -1,6 +1,6 @@
-certoraRun certora/harness/FullMarginEngineExtended.sol certora/harness/GrappaExtended.sol \
-    --verify FullMarginEngineExtended:certora/engine-grappa.spec \
-    --link FullMarginEngineExtended:grappa=GrappaExtended \
+certoraRun certora/harness/FullMarginEngineHarness.sol certora/harness/GrappaHarness.sol \
+    --verify FullMarginEngineHarness:certora/engine-grappa.spec \
+    --link FullMarginEngineHarness:grappa=GrappaHarness \
     --solc_allow_path src \
     --optimistic_loop \
     --packages  solmate=lib/solmate/src \

--- a/src/FullMarginEngine.sol
+++ b/src/FullMarginEngine.sol
@@ -17,8 +17,8 @@ import {TokenIdUtil} from "grappa-core/libraries/TokenIdUtil.sol";
 import {ProductIdUtil} from "grappa-core/libraries/ProductIdUtil.sol";
 
 // Constants and types from Grappa core
-import "grappa-core/config/types.sol";
-import "grappa-core/config/enums.sol";
+import {ActionArgs} from "grappa-core/config/types.sol";
+import {TokenType, ActionType} from "grappa-core/config/enums.sol";
 import "grappa-core/config/errors.sol";
 
 // Full Margin library for FullMarginAccount struct

--- a/src/FullMarginMath.sol
+++ b/src/FullMarginMath.sol
@@ -45,7 +45,10 @@ library FullMarginMath {
                     unchecked {
                         unitAmount = (_account.longStrike - _account.shortStrike);
                     }
-                    unitAmount = unitAmount.mulDivUp(_account.shortAmount, UNIT);
+                    unitAmount = unitAmount * _account.shortAmount;
+                    unchecked {
+                        unitAmount = unitAmount / UNIT;
+                    }
                 } else {
                     // ex: 2000-4000 call spread with eth collateral
                     unchecked {

--- a/src/FullMarginMath.sol
+++ b/src/FullMarginMath.sol
@@ -45,10 +45,7 @@ library FullMarginMath {
                     unchecked {
                         unitAmount = (_account.longStrike - _account.shortStrike);
                     }
-                    unitAmount = unitAmount * _account.shortAmount;
-                    unchecked {
-                        unitAmount = unitAmount / UNIT;
-                    }
+                    unitAmount = unitAmount.mulDivUp(_account.shortAmount, UNIT);
                 } else {
                     // ex: 2000-4000 call spread with eth collateral
                     unchecked {

--- a/src/errors.sol
+++ b/src/errors.sol
@@ -14,6 +14,9 @@ error FM_UnsupportedAction();
 ///      Put spread can only be collateralized by strike (USDC)
 error FM_CannotMintOptionWithThisCollateral();
 
+/// @dev Cannot mint option token with underlying == strike
+error FM_UnderlyingStrikeIdentical();
+
 /// @dev Collateral id is wrong: the id doesn't match the existing collateral
 error FM_WrongCollateralId();
 

--- a/src/errors.sol
+++ b/src/errors.sol
@@ -14,9 +14,6 @@ error FM_UnsupportedAction();
 ///      Put spread can only be collateralized by strike (USDC)
 error FM_CannotMintOptionWithThisCollateral();
 
-/// @dev Cannot mint option token with underlying == strike
-error FM_UnderlyingStrikeIdentical();
-
 /// @dev Collateral id is wrong: the id doesn't match the existing collateral
 error FM_WrongCollateralId();
 


### PR DESCRIPTION
## Summary

* Add rules to determine full collateral logic 

## Details
* Rename `ContractExtended` to `ContractHarness` in certora folders

## Add rule
- [x] put_fully_collateralized
- [x] put_spread_fully_collateralized
- [x] call_fully_collateralized
- [x] call_spread_fully_collateralized_by_strike: call spread collateralized by strike (USDC)
- [ ] call_spread_fully_collateralized_by_underlying: call spread collateralized by collateral (ETH / BTC), this one particularly is still timing out